### PR TITLE
ymlconfig: removed argument from get_model()-call

### DIFF
--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/ymlconfig.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/ymlconfig.py
@@ -118,7 +118,7 @@ def build_analysis_pipeline(analysis_context):
     else:
         parsing_model = func(start['name'],[parserModelDict[start['args']]])
   else:
-    parsing_model = func(start['name'])
+    parsing_model = func()
           
 
 # Some generic imports.


### PR DESCRIPTION
I just changed the parameter for one get_model()-call. I am not sure if the other calls are affected