### PR TITLE
Added copyright to the headers

### DIFF
--- a/source/root/usr/lib/logdata-anomaly-miner/AMiner
+++ b/source/root/usr/lib/logdata-anomaly-miner/AMiner
@@ -1,4 +1,5 @@
 #!/usr/bin/python3 -BbbEIsSttW all
+# -*- coding: utf-8 -*-
 
 """This is the main program of the "aminer" logfile miner tool.
 It does not import any local default site packages to decrease
@@ -23,7 +24,31 @@ Parameters:
 * --RunAnalysis: This parameters is NOT intended to be used on
   command line when starting aminer, it will trigger execution
   of the unprivileged aminer background child performing the real
-  analysis."""
+  analysis.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+__authors__ = ["Markus Wurzenberger", "Max Landauer", "Wolfgang Hotwagner",
+               "Ernst Leierzopf", "Roman Fiedler", "Georg Hoeld"]
+__contact__ = "aecid@ait.ac.at"
+__copyright__ = "Copyright 2020, AIT Austrian Institute of Technology GmbH"
+__credits__ = ["Florian Skopik"]
+__date__ = "2020/06/19"
+__deprecated__ = False
+__email__ = "aecid@ait.ac.at"
+__license__ = "GPLv3"
+__maintainer__ = "Markus Wurzenberger"
+__status__ = "Production"
+__version__ = "2.0.1"
 
 import sys
 # As site packages are not included, define from where we need

--- a/source/root/usr/lib/logdata-anomaly-miner/AMinerRemoteControl
+++ b/source/root/usr/lib/logdata-anomaly-miner/AMinerRemoteControl
@@ -1,9 +1,34 @@
 #!/usr/bin/python3 -BbbEIsSttW all
+# -*- coding: utf-8 -*-
 
 """This tool allows to connect to a remote control socket, send
 requests and retrieve the responses. To allow remote use of this
 tool, e.g. via SSH forwarding, the remote control address can
-be set on the command line, no configuration is read."""
+be set on the command line, no configuration is read.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+__authors__ = ["Markus Wurzenberger", "Max Landauer", "Wolfgang Hotwagner",
+               "Ernst Leierzopf", "Roman Fiedler", "Georg Hoeld"]
+__contact__ = "aecid@ait.ac.at"
+__copyright__ = "Copyright 2020, AIT Austrian Institute of Technology GmbH"
+__credits__ = ["Florian Skopik"]
+__date__ = "2020/06/19"
+__deprecated__ = False
+__email__ = "aecid@ait.ac.at"
+__license__ = "GPLv3"
+__maintainer__ = "Markus Wurzenberger"
+__status__ = "Production"
+__version__ = "2.0.1"
 
 import sys
 # Get rid of the default sys path immediately. Otherwise Python

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/AMinerConfig.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/AMinerConfig.py
@@ -1,4 +1,15 @@
-"""This module collects static configuration item keys and configuration loading and handling functions."""
+"""This module collects static configuration item keys and configuration loading and handling functions.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import os
 import sys

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/AMinerRemoteControlExecutionMethods.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/AMinerRemoteControlExecutionMethods.py
@@ -1,4 +1,15 @@
-"""This module contains methods which can be executed from the AMinerRemoteControl class."""
+"""This module contains methods which can be executed from the AMinerRemoteControl class.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 import aminer
 from aminer import AMinerConfig, AnalysisChild
 import resource

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/AnalysisChild.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/AnalysisChild.py
@@ -1,4 +1,15 @@
-"""This module contains classes for execution of py child process main analysis loop."""
+"""This module contains classes for execution of py child process main analysis loop.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import base64
 import errno

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/AtomFilters.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/AtomFilters.py
@@ -1,5 +1,16 @@
 """This file collects various classes useful to filter log atoms
-and pass them to different handlers."""
+and pass them to different handlers.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from aminer.input import AtomHandlerInterface
 

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/EnhancedNewMatchPathValueComboDetector.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/EnhancedNewMatchPathValueComboDetector.py
@@ -1,6 +1,17 @@
 """This file defines the EnhancedNewMatchPathValueComboDetector
 detector to extract values from LogAtoms and check, if the value
-combination was already seen before."""
+combination was already seen before.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import time
 import os

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/HistogramAnalysis.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/HistogramAnalysis.py
@@ -39,6 +39,16 @@ a report every week:
       reset_after_report_flag=True)  # Zero counters after sending of report
   # Send the appropriate input feed to the component
   atomFilter.addHandler(histogramAnalysis)
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
 import time

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/MatchValueAverageChangeDetector.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/MatchValueAverageChangeDetector.py
@@ -1,5 +1,16 @@
 """This module defines a detector that reports diverges from
-an average."""
+an average.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import time
 import os

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/MatchValueStreamWriter.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/MatchValueStreamWriter.py
@@ -1,4 +1,15 @@
-"""This module dfines a writer that forwards match information to a stream."""
+"""This module dfines a writer that forwards match information to a stream.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from aminer.AnalysisChild import AnalysisContext
 from aminer.input import AtomHandlerInterface

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/MissingMatchPathValueDetector.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/MissingMatchPathValueDetector.py
@@ -1,5 +1,16 @@
 """This module provides the MissingMatchPathValueDetector to generate events when expected values were not seen for an extended period
-of time."""
+of time.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import time
 

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/NewMatchIdValueComboDetector.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/NewMatchIdValueComboDetector.py
@@ -1,6 +1,17 @@
 """This file defines the NewMatchIdValueComboDetector
 detector to extract values from multiple LogAtoms and check, if the value
-combination was already seen before."""
+combination was already seen before.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import time
 import os

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/NewMatchPathDetector.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/NewMatchPathDetector.py
@@ -1,4 +1,15 @@
-"""This module defines a detector for new data paths."""
+"""This module defines a detector for new data paths.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import time
 import os

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/NewMatchPathValueComboDetector.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/NewMatchPathValueComboDetector.py
@@ -1,6 +1,17 @@
 """This file defines the basic NewMatchPathValueComboDetector
 detector to extract values from LogAtoms and check, if the value
-combination was already seen before."""
+combination was already seen before.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import time
 import os

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/NewMatchPathValueDetector.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/NewMatchPathValueDetector.py
@@ -1,4 +1,15 @@
-"""This module defines a detector for new values in a data path."""
+"""This module defines a detector for new values in a data path.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import time
 import os

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/ParserCount.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/ParserCount.py
@@ -1,4 +1,15 @@
-"""This component counts occurring combinations of values and periodically sends the results as a report."""
+"""This component counts occurring combinations of values and periodically sends the results as a report.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import datetime
 import time

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/Rules.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/Rules.py
@@ -2,7 +2,18 @@
 The ruleset also supports parallel rule evaluation, e.g. the two
 rules "A and B and C" and "A and B and D" will only peform the
 checks for A and B once, then performs check C and D and trigger
-a match action."""
+a match action.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import datetime
 import sys

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/TimeCorrelationDetector.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/TimeCorrelationDetector.py
@@ -1,4 +1,15 @@
-"""This module defines a detector for time correlation between atoms."""
+"""This module defines a detector for time correlation between atoms.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from datetime import datetime
 import random

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/TimeCorrelationViolationDetector.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/TimeCorrelationViolationDetector.py
@@ -1,4 +1,15 @@
-"""This module defines a detector for time correlation rules."""
+"""This module defines a detector for time correlation rules.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import time
 

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/TimestampCorrectionFilters.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/TimestampCorrectionFilters.py
@@ -1,4 +1,15 @@
-"""This file collects various classes useful to filter and correct the timestamp associated with a received parsed atom."""
+"""This file collects various classes useful to filter and correct the timestamp associated with a received parsed atom.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from aminer.input import AtomHandlerInterface
 

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/TimestampsUnsortedDetector.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/TimestampsUnsortedDetector.py
@@ -1,4 +1,15 @@
-"""This module defines a detector for unsorted timestamps."""
+"""This module defines a detector for unsorted timestamps.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import os
 

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/WhitelistViolationDetector.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/WhitelistViolationDetector.py
@@ -1,5 +1,16 @@
 """This module defines a detector for log atoms not matching
-any whitelisted rule."""
+any whitelisted rule.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import os
 

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/events/DefaultMailNotificationEventHandler.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/events/DefaultMailNotificationEventHandler.py
@@ -1,4 +1,15 @@
-"""This module defines the event handler for reporting via emails."""
+"""This module defines the event handler for reporting via emails.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import email.mime.text
 import os

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/events/EventData.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/events/EventData.py
@@ -1,3 +1,14 @@
+"""
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 from datetime import datetime
 from aminer.analysis import CONFIG_KEY_LOG_LINE_PREFIX
 

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/events/JsonConverterHandler.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/events/JsonConverterHandler.py
@@ -1,4 +1,15 @@
-"""This module defines an event handler that converts an event to JSON."""
+"""This module defines an event handler that converts an event to JSON.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import json
 import time

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/events/KafkaEventHandler.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/events/KafkaEventHandler.py
@@ -1,4 +1,15 @@
-"""This module defines an event handler that forwards Json-objects to Kafka."""
+"""This module defines an event handler that forwards Json-objects to Kafka.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import sys
 from aminer.events import EventHandlerInterface

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/events/StreamPrinterEventHandler.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/events/StreamPrinterEventHandler.py
@@ -1,5 +1,16 @@
 """This module defines an event handler that prints data to
-a stream."""
+a stream.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import sys
 

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/events/SyslogWriterEventHandler.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/events/SyslogWriterEventHandler.py
@@ -1,5 +1,16 @@
 """This module defines an event handler that prints data to
-a local syslog instance."""
+a local syslog instance.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import io
 import os

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/events/Utils.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/events/Utils.py
@@ -1,4 +1,15 @@
-"""This module defines a handler for storing event history."""
+"""This module defines a handler for storing event history.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from aminer.events import EventHandlerInterface
 from aminer.util import LogarithmicBackoffHistory

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/input/ByteStreamLineAtomizer.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/input/ByteStreamLineAtomizer.py
@@ -1,5 +1,16 @@
 """This module provides support for splitting a data stream into
-atoms, perform parsing and forward the results."""
+atoms, perform parsing and forward the results.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from aminer.input.LogAtom import LogAtom
 from aminer.input import StreamAtomizer

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/input/LogAtom.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/input/LogAtom.py
@@ -1,4 +1,15 @@
-"""This module defines a log atom."""
+"""This module defines a log atom.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 
 class LogAtom:

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/input/LogStream.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/input/LogStream.py
@@ -1,4 +1,15 @@
-"""This module contains interfaces and classes for logdata resource handling and combining them to resumable virtual LogStream objects."""
+"""This module contains interfaces and classes for logdata resource handling and combining them to resumable virtual LogStream objects.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import base64
 import errno

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/input/SimpleByteStreamLineAtomizerFactory.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/input/SimpleByteStreamLineAtomizerFactory.py
@@ -1,4 +1,15 @@
-"""This module defines a factory for instanciating line atomizers."""
+"""This module defines a factory for instanciating line atomizers.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from aminer.input import AtomizerFactory
 from aminer.input.ByteStreamLineAtomizer import ByteStreamLineAtomizer

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/input/SimpleMultisourceAtomSync.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/input/SimpleMultisourceAtomSync.py
@@ -1,5 +1,16 @@
 """This module defines a handler that synchronizes different
-streams."""
+streams.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import time
 from aminer.input import AtomHandlerInterface

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/input/SimpleUnparsedAtomHandler.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/input/SimpleUnparsedAtomHandler.py
@@ -1,5 +1,16 @@
 """This module defines a handler that forwards unparsed atoms
-to the event handlers."""
+to the event handlers.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from aminer.input import AtomHandlerInterface
 

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/input/VerboseUnparsedAtomHandler.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/input/VerboseUnparsedAtomHandler.py
@@ -1,4 +1,15 @@
-"""This module defines a handler that forwards unparsed atoms to the event handlers."""
+"""This module defines a handler that forwards unparsed atoms to the event handlers.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from aminer.input import AtomHandlerInterface
 from aminer.parsing import DebugMatchContext

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/AnyByteDataModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/AnyByteDataModelElement.py
@@ -1,4 +1,15 @@
-"""This module defines a model element that matches any byte."""
+"""This module defines a model element that matches any byte.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from aminer.parsing.MatchElement import MatchElement
 from aminer.parsing import ModelElementInterface

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/Base64StringModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/Base64StringModelElement.py
@@ -1,4 +1,16 @@
-"""This module provides base64 string matching."""
+"""This module provides base64 string matching.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
 
 import base64
 

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/DateTimeModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/DateTimeModelElement.py
@@ -1,4 +1,16 @@
-"""This module contains a datetime parser and helper classes for parsing."""
+"""This module contains a datetime parser and helper classes for parsing.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
 
 import datetime
 import sys

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/DebugModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/DebugModelElement.py
@@ -1,5 +1,16 @@
 """This moduel defines a debug model element that can be used to check whether a specific poistion in the parsing tree is reached
-by log atoms."""
+by log atoms.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import sys
 

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/DecimalFloatValueModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/DecimalFloatValueModelElement.py
@@ -1,4 +1,16 @@
-"""This module defines an model element for decimal number parsing as float."""
+"""This module defines an model element for decimal number parsing as float.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
 
 from aminer.parsing import ModelElementInterface
 from aminer.parsing.MatchElement import MatchElement

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/DecimalIntegerValueModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/DecimalIntegerValueModelElement.py
@@ -1,4 +1,15 @@
-"""This module defines an model element for integer number parsing."""
+"""This module defines an model element for integer number parsing.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from aminer.parsing import ModelElementInterface
 from aminer.parsing.MatchElement import MatchElement

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/DelimitedDataModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/DelimitedDataModelElement.py
@@ -1,4 +1,15 @@
-"""This module defines a model element that takes any string up to a specific delimiter string."""
+"""This module defines a model element that takes any string up to a specific delimiter string.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from aminer.parsing.MatchElement import MatchElement
 from aminer.parsing import ModelElementInterface

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/ElementValueBranchModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/ElementValueBranchModelElement.py
@@ -1,4 +1,16 @@
-"""This module defines a model element that allows branches depending on the value of the previous model value."""
+"""This module defines a model element that allows branches depending on the value of the previous model value.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
 
 from aminer.parsing import ModelElementInterface
 from aminer.parsing.MatchElement import MatchElement

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/FirstMatchModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/FirstMatchModelElement.py
@@ -1,4 +1,16 @@
-"""This module defines a model element that allows branches. The first matching branch is taken."""
+"""This module defines a model element that allows branches. The first matching branch is taken.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
 
 from aminer.parsing import ModelElementInterface
 

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/FixedDataModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/FixedDataModelElement.py
@@ -1,4 +1,16 @@
-"""This module defines a model element representing a fixed string."""
+"""This module defines a model element representing a fixed string.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
 
 from aminer.parsing.MatchElement import MatchElement
 from aminer.parsing import ModelElementInterface

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/FixedWordlistDataModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/FixedWordlistDataModelElement.py
@@ -1,4 +1,15 @@
-"""This module defines a model element to detect fixed strings from a list of words."""
+"""This module defines a model element to detect fixed strings from a list of words.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from aminer.parsing import ModelElementInterface
 from aminer.parsing.MatchElement import MatchElement

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/HexStringModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/HexStringModelElement.py
@@ -1,4 +1,16 @@
-"""This module defines a model element that represents a hex string of arbitrary length."""
+"""This module defines a model element that represents a hex string of arbitrary length.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
 
 from aminer.parsing.MatchElement import MatchElement
 from aminer.parsing import ModelElementInterface

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/IpAddressDataModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/IpAddressDataModelElement.py
@@ -1,4 +1,16 @@
-"""This module defines a model element that represents an IP address."""
+"""This module defines a model element that represents an IP address.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
 
 from aminer.parsing.MatchElement import MatchElement
 from aminer.parsing import ModelElementInterface

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/MatchContext.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/MatchContext.py
@@ -1,4 +1,15 @@
-"""This module defines the match context."""
+"""This module defines the match context.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from aminer.parsing.MatchElement import MatchElement
 

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/MatchElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/MatchElement.py
@@ -1,4 +1,15 @@
-"""This module provides only the MatchElement class to store results from parser element matching process."""
+"""This module provides only the MatchElement class to store results from parser element matching process.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 
 class MatchElement:

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/MultiLocaleDateTimeModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/MultiLocaleDateTimeModelElement.py
@@ -1,4 +1,15 @@
-"""This module defines a model element representing date or datetime from sources with different locales."""
+"""This module defines a model element representing date or datetime from sources with different locales.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import datetime
 import locale

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/OptionalMatchModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/OptionalMatchModelElement.py
@@ -1,4 +1,15 @@
-"""This module defines a model element that is optional."""
+"""This module defines a model element that is optional.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from aminer.parsing.MatchElement import MatchElement
 from aminer.parsing import ModelElementInterface

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/ParserMatch.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/ParserMatch.py
@@ -1,4 +1,16 @@
-"""This module defines a matching parser model element."""
+"""This module defines a matching parser model element.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
 
 from collections import deque
 

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/RepeatedElementDataModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/RepeatedElementDataModelElement.py
@@ -1,4 +1,16 @@
-"""This module defines a model element that repeats a number of times."""
+"""This module defines a model element that repeats a number of times.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+
 
 from aminer.parsing.MatchElement import MatchElement
 from aminer.parsing import ModelElementInterface

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/SequenceModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/SequenceModelElement.py
@@ -1,4 +1,15 @@
-"""This module defines a model element that consists of a sequence of model elements that all have to match."""
+"""This module defines a model element that consists of a sequence of model elements that all have to match.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from aminer.parsing.MatchElement import MatchElement
 from aminer.parsing import ModelElementInterface

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/VariableByteDataModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/VariableByteDataModelElement.py
@@ -1,4 +1,15 @@
-"""This module defines a model element for a variable amount of bytes."""
+"""This module defines a model element for a variable amount of bytes.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from aminer.parsing.MatchElement import MatchElement
 from aminer.parsing import ModelElementInterface

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/WhiteSpaceLimitedDataModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/WhiteSpaceLimitedDataModelElement.py
@@ -1,4 +1,15 @@
-"""This module defines a model element that takes any string up to the next white space."""
+"""This module defines a model element that takes any string up to the next white space.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from aminer.parsing.MatchElement import MatchElement
 from aminer.parsing import ModelElementInterface

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/schema.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/schema.py
@@ -1,3 +1,15 @@
+""" This schema validates the config-files in yaml-format
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 # skipcq: PYL-W0104
 {
         'LearnMode': {

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/util/JsonUtil.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/util/JsonUtil.py
@@ -1,4 +1,15 @@
-"""This module converts json strings to object structures also supporting byte array structures."""
+"""This module converts json strings to object structures also supporting byte array structures.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 import json
 
 from aminer.util import encode_byte_string_as_string, decode_string_as_byte_string

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/util/PersistencyUtil.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/util/PersistencyUtil.py
@@ -1,4 +1,15 @@
-"""This module defines functions for reading and writing files in a secure way."""
+"""This module defines functions for reading and writing files in a secure way.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import errno
 import os

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/util/SecureOSFunctions.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/util/SecureOSFunctions.py
@@ -1,4 +1,15 @@
-"""This module defines functions for secure file handling."""
+"""This module defines functions for secure file handling.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 
 import os
 import socket

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/ymlconfig.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/ymlconfig.py
@@ -1,3 +1,15 @@
+""" This file loads and parses a config-file in yaml format.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <http://www.gnu.org/licenses/>.
+"""
 config_properties = {}
 yamldata = None
 


### PR DESCRIPTION
This commit adds the copyright to the headers of the python files.
It further sets the executable bit at the AMiner.py