### PR TITLE
Fix Contradicting interval settings in MissingMatchPathValueDetector

### DIFF
--- a/aecid-testsuite/unit/analysis/MissingMatchPathValueDetectorTest.py
+++ b/aecid-testsuite/unit/analysis/MissingMatchPathValueDetectorTest.py
@@ -117,8 +117,8 @@ class MissingMatchPathValueDetectorTest(TestBase):
         other_missing_match_path_value_detector = MissingMatchPathValueDetector(self.aminer_config, match_element_fixed_dme.get_path(), [
             self.stream_printer_event_handler], 'Default', True, self.__default_interval, self.__realert_interval)
         self.analysis_context.register_component(other_missing_match_path_value_detector, description + "2")
-        other_missing_match_path_value_detector.set_check_value(other_missing_match_path_value_detector.get_channel_key(log_atom_fixed_dme),
-                                                                self.__default_interval - past_time, match_element_fixed_dme.get_path())
+        other_missing_match_path_value_detector.set_check_value(other_missing_match_path_value_detector.get_channel_key(
+            log_atom_fixed_dme)[1], self.__default_interval - past_time, match_element_fixed_dme.get_path())
 
         log_atom_fixed_dme = LogAtom(fixed_dme.fixed_data, ParserMatch(match_element_fixed_dme), round(time.time()) + past_time,
                                      other_missing_match_path_value_detector)
@@ -267,7 +267,7 @@ class MissingMatchPathValueDetectorTest(TestBase):
             'Default', True, self.__default_interval, self.__realert_interval)
         self.analysis_context.register_component(other_missing_match_path_list_value_detector, description + "2")
         other_missing_match_path_list_value_detector.set_check_value(other_missing_match_path_list_value_detector.get_channel_key(
-            log_atom_fixed_dme), self.__default_interval - past_time, match_element_fixed_dme.get_path())
+            log_atom_fixed_dme)[1], self.__default_interval - past_time, match_element_fixed_dme.get_path())
 
         log_atom_fixed_dme = LogAtom(fixed_dme.fixed_data, ParserMatch(match_element_fixed_dme), round(time.time()) + past_time,
                                      other_missing_match_path_list_value_detector)

--- a/aecid-testsuite/unit/analysis/MissingMatchPathValueDetectorTest.py
+++ b/aecid-testsuite/unit/analysis/MissingMatchPathValueDetectorTest.py
@@ -118,7 +118,7 @@ class MissingMatchPathValueDetectorTest(TestBase):
             self.stream_printer_event_handler], 'Default', True, self.__default_interval, self.__realert_interval)
         self.analysis_context.register_component(other_missing_match_path_value_detector, description + "2")
         other_missing_match_path_value_detector.set_check_value(other_missing_match_path_value_detector.get_channel_key(log_atom_fixed_dme),
-                                                                self.__default_interval - past_time)
+                                                                self.__default_interval - past_time, match_element_fixed_dme.get_path())
 
         log_atom_fixed_dme = LogAtom(fixed_dme.fixed_data, ParserMatch(match_element_fixed_dme), round(time.time()) + past_time,
                                      other_missing_match_path_value_detector)
@@ -266,8 +266,8 @@ class MissingMatchPathValueDetectorTest(TestBase):
             match_element_fixed_dme.get_path(), match_element_decimal_integer_value_me.get_path()], [self.stream_printer_event_handler],
             'Default', True, self.__default_interval, self.__realert_interval)
         self.analysis_context.register_component(other_missing_match_path_list_value_detector, description + "2")
-        other_missing_match_path_list_value_detector.set_check_value(
-            other_missing_match_path_list_value_detector.get_channel_key(log_atom_fixed_dme), self.__default_interval - past_time)
+        other_missing_match_path_list_value_detector.set_check_value(other_missing_match_path_list_value_detector.get_channel_key(
+            log_atom_fixed_dme), self.__default_interval - past_time, match_element_fixed_dme.get_path())
 
         log_atom_fixed_dme = LogAtom(fixed_dme.fixed_data, ParserMatch(match_element_fixed_dme), round(time.time()) + past_time,
                                      other_missing_match_path_list_value_detector)

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/MissingMatchPathValueDetector.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/MissingMatchPathValueDetector.py
@@ -83,7 +83,7 @@ class MissingMatchPathValueDetector(AtomHandlerInterface, TimeTriggeredComponent
         timestamp = log_atom.get_timestamp()
         if timestamp is None:
             timestamp = time.time()
-        detector_info = self.expected_values_dict.get(value, None)
+        detector_info = self.expected_values_dict.get(value)
         if detector_info is not None:
             # Just update the last seen value and switch from non-reporting error state to normal state.
             detector_info[0] = timestamp
@@ -105,7 +105,7 @@ class MissingMatchPathValueDetector(AtomHandlerInterface, TimeTriggeredComponent
 
     def get_channel_key(self, log_atom):
         """Get the key identifying the channel this log_atom is coming from."""
-        match_element = log_atom.parser_match.get_match_dictionary().get(self.target_path, None)
+        match_element = log_atom.parser_match.get_match_dictionary().get(self.target_path)
         if match_element is None:
             return None
         if isinstance(match_element.match_object, bytes):
@@ -237,11 +237,11 @@ class MissingMatchPathValueDetector(AtomHandlerInterface, TimeTriggeredComponent
         new_interval = allowlisting_data
         if new_interval == -1:
             new_interval = self.default_interval
-        for key_name, in event_data:
+        for key_name, target_path in event_data:
             if new_interval < 0:
                 self.remove_check_value(key_name)
             else:
-                self.set_check_value(key_name, new_interval)
+                self.set_check_value(key_name, new_interval, target_path)
         return 'Updated %d entries' % len(event_data)
 
 
@@ -266,7 +266,7 @@ class MissingMatchPathListValueDetector(MissingMatchPathValueDetector):
     def get_channel_key(self, log_atom):
         """Get the key identifying the channel this log_atom is coming from."""
         for target_path in self.target_path_list:
-            match_element = log_atom.parser_match.get_match_dictionary().get(target_path, None)
+            match_element = log_atom.parser_match.get_match_dictionary().get(target_path)
             if match_element is None:
                 continue
             if isinstance(match_element.match_object, bytes):

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/MissingMatchPathValueDetector.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/MissingMatchPathValueDetector.py
@@ -54,18 +54,19 @@ class MissingMatchPathValueDetector(AtomHandlerInterface, TimeTriggeredComponent
         self.persistence_file_name = AMinerConfig.build_persistence_file_name(aminer_config, self.__class__.__name__, persistence_id)
         persistence_data = PersistenceUtil.load_json(self.persistence_file_name)
         self.expected_values_dict = {}
-        for key in persistence_data:
-            value = persistence_data[key]
-            if self.target_path is not None:
-                if value[3] != self.target_path:
-                    continue
-            elif self.target_path_list is not None:
-                if value[3] not in self.target_path_list:
-                    continue
-            if value[1] != default_interval:
-                value[1] = default_interval
-                value[2] = value[0] + default_interval
-            self.expected_values_dict[key] = value
+        if persistence_data is not None:
+            for key in persistence_data:
+                value = persistence_data[key]
+                if self.target_path is not None:
+                    if value[3] != self.target_path:
+                        continue
+                elif self.target_path_list is not None:
+                    if value[3] not in self.target_path_list:
+                        continue
+                if value[1] != default_interval:
+                    value[1] = default_interval
+                    value[2] = value[0] + default_interval
+                self.expected_values_dict[key] = value
         self.analysis_string = 'Analysis.%s'
 
     def receive_atom(self, log_atom):


### PR DESCRIPTION
Development

# Make sure these boxes are signed before submitting your Pull Request -- thank you.

# Must haves
- [x] I have read and followed the contributing guide lines at https://github.com/ait-aecid/logdata-anomaly-miner/wiki/Git-development-workflow
- [x] Issues exist for this PR
- [x] I added related issues using the "Fixes #123'-notations
- [x] This Pull-Requests merges into the "development"-branch

# Submission specific

- [ ] This PR introduces breaking changes
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

# Describe changes:
- The new implementation also persists paths and removes changed paths when loading from persisted data.
- After loading the intervals and next check times are reset from the new configuration if and only if the default_interval was changed.
-
Fixes #117