### PR TITLE
Install: use specific branch for aminer-ansible

### DIFF
--- a/scripts/aminer_install.sh
+++ b/scripts/aminer_install.sh
@@ -51,7 +51,7 @@ fi
 git clone -b $BRANCH $URL $AMINERSRC
 cd $AMINERSRC
 mkdir roles
-git clone https://github.com/ait-aecid/aminer-ansible roles/aminer
+git clone -b $BRANCH https://github.com/ait-aecid/aminer-ansible roles/aminer
 
 
 cat > playbook.yml << EOF


### PR DESCRIPTION
This commit adds a branch-name for aminer-ansible to the install-script

# Make sure these boxes are signed before submitting your Pull Request -- thank you.

# Must haves
- [x] I have read and followed the contributing guide lines at https://github.com/ait-aecid/logdata-anomaly-miner/wiki/Git-development-workflow
- [] Issues exist for this PR
- [ ] I added related issues using the "Fixes #123'-notations
- [x] This Pull-Requests merges into the "development"-branch

# Submission specific

- [ ] This PR introduces breaking changes
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

# Describe changes:
- adds branch-option to clone of aminer-ansible in install-script
