### PR TITLE
Fix: too many open directory-handles

### DIFF
--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/util/SecureOSFunctions.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/util/SecureOSFunctions.py
@@ -140,7 +140,9 @@ def secure_open_file(file_name, flags):
     dir_name = os.path.dirname(file_name)
     base_name = os.path.basename(file_name)
     dir_fd = os.open(dir_name, flags | os.O_NOFOLLOW | os.O_NOCTTY | os.O_DIRECTORY)
-    return os.open(base_name, flags | os.O_NOFOLLOW | os.O_NOCTTY, dir_fd=dir_fd)
+    ret_fd = os.open(base_name, flags | os.O_NOFOLLOW | os.O_NOCTTY, dir_fd=dir_fd)
+    os.close(dir_fd)
+    return ret_fd
 
 
 def send_annotated_file_descriptor(send_socket, send_fd, type_info, annotation_data):


### PR DESCRIPTION
This patch fixes a problem with too many open file-handles. This problem
occurs with open directory-handles of resource-files.

# Make sure these boxes are signed before submitting your Pull Request -- thank you.

# Must haves
- [x] I have read and followed the contributing guide lines at https://github.com/ait-aecid/logdata-anomaly-miner/wiki/Git-development-workflow
- [x] Issues exist for this PR
- [x] I added related issues using the "Fixes #123'-notations
- [x] This Pull-Requests merges into the "development"-branch

Fixes #388 

# Submission specific

- [ ] This PR introduces breaking changes
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

# Describe changes:
-  closes the dir_fd in secure_open_file()