### PR TITLE
aminer.py: resolved hardcoded username and gropname where user_id and…

### DIFF
--- a/source/root/usr/lib/logdata-anomaly-miner/aminer.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer.py
@@ -520,7 +520,20 @@ def main():
         else:
             msg = 'INFO: No privilege separation when started as unprivileged user'
             print(msg, file=sys.stderr)
-            initialize_loggers(aminer_config, 'aminer', 'aminer')
+            tmp_username = aminer_config.config_properties.get(AminerConfig.KEY_AMINER_USER)
+            tmp_group = aminer_config.config_properties.get(AminerConfig.KEY_AMINER_GROUP)
+            aminer_user_id = -1
+            aminer_group_id = -1
+            try:
+                if tmp_username is not None:
+                    aminer_user_id = getpwnam(tmp_username).pw_uid
+                if tmp_group is not None:
+                    aminer_group_id = getgrnam(tmp_group).gr_gid
+            except:  # skipcq: FLK-E722
+                print('Failed to resolve %s or %s' % (AminerConfig.KEY_AMINER_USER, AminerConfig.KEY_AMINER_GROUP), file=sys.stderr)
+                sys.exit(1)
+
+            initialize_loggers(aminer_config, aminer_user_id, aminer_group_id)
             logging.getLogger(AminerConfig.DEBUG_LOG_NAME).info(msg)
 
         # Now resolve the specific analysis configuration file (if any).

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer.py
@@ -281,7 +281,7 @@ def main():
         if child_user_name is not None:
             child_user_id = getpwnam(child_user_name).pw_uid
         if child_group_name is not None:
-            child_group_id = getgrnam(child_user_name).gr_gid
+            child_group_id = getgrnam(child_group_name).gr_gid
     except:  # skipcq: FLK-E722
         print('Failed to resolve %s or %s' % (AminerConfig.KEY_AMINER_USER, AminerConfig.KEY_AMINER_GROUP), file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
… group_id was expected

# Make sure these boxes are signed before submitting your Pull Request -- thank you.

# Must haves
- [x] I have read and followed the contributing guide lines at https://github.com/ait-aecid/logdata-anomaly-miner/wiki/Git-development-workflow
- [ ] Issues exist for this PR
- [ ] I added related issues using the "Fixes #<issue-id>"-notations
- [x] This Pull-Requests merges into the "development"-branch

Fixes problems without an issue(sorry)

# Submission specific

- [ ] This PR introduces breaking changes
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

# Describe changes:
-  fetch username and group from aminer-config
-  resolve to user_id and group_id
- call initialize_logger with user_id and group_id