### PR TITLE
121 fixed issue with paths in JsonModelElement.

### DIFF
--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/JsonModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/JsonModelElement.py
@@ -318,11 +318,15 @@ class JsonModelElement(ModelElementInterface):
             data = str(data).encode()
         if json_dict[key] == "ALLOW_ALL":
             logging.getLogger(DEBUG_LOG_NAME).debug(debug_log_prefix + "ALLOW_ALL (DICT)", data.decode())
-            match_element = MatchElement(current_path+"/"+key, data, data, None)
-            last_bracket = match_context.match_data.find(b"}", len(data))
-            while match_context.match_data.count(b"{", 0, last_bracket) - match_context.match_data.count(b"}", 0, last_bracket) > 0:
-                last_bracket = match_context.match_data.find(b"}", last_bracket) + 1
-            index = last_bracket - len(data)
+            if data.startswith(b"{"):
+                match_element = MatchElement(current_path, data, data, None)
+                last_bracket = match_context.match_data.find(b"}", len(data))
+                while match_context.match_data.count(b"{", 0, last_bracket) - match_context.match_data.count(b"}", 0, last_bracket) > 0:
+                    last_bracket = match_context.match_data.find(b"}", last_bracket) + 1
+                index = last_bracket - len(data)
+            else:
+                match_element = None
+                index = -1
         else:
             match_element = json_dict[key].get_match_element(current_path, MatchContext(data))
             if match_element is not None and len(match_element.match_string) != len(data) and (

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/JsonModelElement.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/parsing/JsonModelElement.py
@@ -177,7 +177,8 @@ class JsonModelElement(ModelElementInterface):
             elif value == "EMPTY_OBJECT":
                 if isinstance(json_match_data[split_key], dict) and len(json_match_data[split_key].keys()) == 0:
                     index = match_context.match_data.find(b"}") + 1
-                    match_element = MatchElement(current_path, match_context.match_data[:index], match_context.match_data[:index], None)
+                    match_element = MatchElement(
+                        current_path+"/"+key, match_context.match_data[:index], match_context.match_data[:index], None)
                     matches.append(match_element)
                     match_context.update(match_context.match_data[:index])
                 else:
@@ -185,7 +186,8 @@ class JsonModelElement(ModelElementInterface):
             elif json_dict[key] == "EMPTY_LIST":
                 if isinstance(json_match_data[split_key], list) and len(json_match_data[split_key]) == 0:
                     index = match_context.match_data.find(b"]") + 1
-                    match_element = MatchElement(current_path, match_context.match_data[:index], match_context.match_data[:index], None)
+                    match_element = MatchElement(
+                        current_path+"/"+key, match_context.match_data[:index], match_context.match_data[:index], None)
                     matches.append(match_element)
                     match_context.update(match_context.match_data[:index])
                 else:
@@ -260,11 +262,12 @@ class JsonModelElement(ModelElementInterface):
             else:
                 if json_dict[key][0] == "ALLOW_ALL":
                     logging.getLogger(DEBUG_LOG_NAME).debug(debug_log_prefix + "ALLOW_ALL (LIST)")
-                    match_element = MatchElement(current_path, data, data, None)
+                    match_element = MatchElement(current_path+"/"+key, data, data, None)
                 elif json_dict[key] == "EMPTY_LIST":
                     if isinstance(data, list) and len(data) == 0:
                         index = match_context.match_data.find(b"]")
-                        match_element = MatchElement(current_path, match_context.match_data[:index], match_context.match_data[:index], None)
+                        match_element = MatchElement(
+                            current_path+"/"+key, match_context.match_data[:index], match_context.match_data[:index], None)
                         match_context.update(match_context.match_data[:index])
                     else:
                         return None
@@ -315,7 +318,7 @@ class JsonModelElement(ModelElementInterface):
             data = str(data).encode()
         if json_dict[key] == "ALLOW_ALL":
             logging.getLogger(DEBUG_LOG_NAME).debug(debug_log_prefix + "ALLOW_ALL (DICT)", data.decode())
-            match_element = MatchElement(current_path, data, data, None)
+            match_element = MatchElement(current_path+"/"+key, data, data, None)
             last_bracket = match_context.match_data.find(b"}", len(data))
             while match_context.match_data.count(b"{", 0, last_bracket) - match_context.match_data.count(b"}", 0, last_bracket) > 0:
                 last_bracket = match_context.match_data.find(b"}", last_bracket) + 1


### PR DESCRIPTION
# Make sure these boxes are signed before submitting your Pull Request -- thank you.

# Must haves
- [x] I have read and followed the contributing guide lines at https://github.com/ait-aecid/logdata-anomaly-miner/wiki/Git-development-workflow
- [x] Issues exist for this PR
- [x] I added related issues using the "Fixes #<issue-id>"-notations
- [x] This Pull-Requests merges into the "development"-branch

Fixes #775

# Submission specific

- [ ] This PR introduces breaking changes
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

# Describe changes:
I have reproduced the results and came to the conclusion that there is a configuration error, no bug.
ALLOW_ALL is not intended to be used for simple strings - instead only full objects and lists can be parsed with ALLOW_ALL.

I have changed the example config as follows:
```
       - id: json
         start: True
         type: JsonModelElement
         name: 'model'
         key_parser_dict:
           "aa": a
           fields:
             "bb": b
             "cc":
              - ALLOW_ALL
             "dd": d
```
Using ALLOW_ALL in the cc list works as intended with following results (note: I have already fixed the issue with the paths):
```
2021-07-12 12:18:38 New path(es) detected
NewMatchPathDetector: "DefaultNewMatchPathDetector" (1 lines)
  {
  "AnalysisComponent": {
    "AnalysisComponentIdentifier": 1,
    "AnalysisComponentType": "NewMatchPathDetector",
    "AnalysisComponentName": "DefaultNewMatchPathDetector",
    "Message": "New path(es) detected",
    "PersistenceFileName": "Default",
    "AffectedLogAtomPaths": [
      "/model",
      "/model/a",
      "/model/fields/b",
      "/model/fields/cc",
      "/model/fields/d"
    ],
    "ParsedLogAtom": {
      "/model": {
        "aa": "a1",
        "fields": {
          "bb": "b1",
          "cc": [
            "c1"
          ],
          "dd": "d1"
        }
      },
      "/model/a": "a1",
      "/model/fields/b": "b1",
      "/model/fields/cc": "c1",
      "/model/fields/d": "d1"
    }
  },
  "LogData": {
    "RawLogData": [
      "{\n  \"aa\": \"a1\",\n  \"fields\": {\n    \"bb\": \"b1\",\n    \"cc\": [\n      \"c1\"\n    ],\n    \"dd\": \"d1\"\n  }\n}"
    ],
    "Timestamps": [
      1626085118.79
    ],
    "DetectionTimestamp": 1626085118.79,
    "LogLinesCount": 1,
    "AnnotatedMatchElement": "/model: {'aa': 'a1', 'fields': {'bb': 'b1', 'cc': ['c1'], 'dd': 'd1'}}\n  /model/a: a1\n  /model/fields/b: b1\n  /model/fields/cc: c1\n  /model/fields/d: d1"
  }
}
```
