### PR TITLE
127 improved error message.

### DIFF
--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/YamlConfig.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/YamlConfig.py
@@ -228,6 +228,11 @@ def build_parsing_model():
                 parser_model_dict[item['id']] = item['type'].func(item['name'], item['value_sign_type'], item['value_pad_type'])
             elif item['type'].name in ('FirstMatchModelElement', 'SequenceModelElement'):
                 children = []
+                if not isinstance(item['args'], list):
+                    msg = '"args" has to be a list when using the %s. Currently args is defined as %s' % (
+                        item['type'].name, repr(item['args']))
+                    logging.getLogger(DEBUG_LOG_NAME).error(msg)
+                    raise TypeError(msg)
                 for child in item['args']:
                     if isinstance(child, bytes):
                         child = child.decode()


### PR DESCRIPTION
# Make sure these boxes are signed before submitting your Pull Request -- thank you.

# Must haves
- [x] I have read and followed the contributing guide lines at https://github.com/ait-aecid/logdata-anomaly-miner/wiki/Git-development-workflow
- [x] Issues exist for this PR
- [x] I added related issues using the "Fixes #<issue-id>"-notations
- [x] This Pull-Requests merges into the "development"-branch

Fixes #719

# Submission specific

- [ ] This PR introduces breaking changes
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

# Describe changes:
The new error message looks like this:
```
WARNING: file or socket '/home/ubuntu/xyz.log' does not exist (yet)!
Traceback (most recent call last):
  File "/usr/bin/aminer", line 751, in <module>
    main()
  File "/usr/bin/aminer", line 476, in main
    run_analysis_child(aminer_config, program_name)
  File "/usr/bin/aminer", line 88, in run_analysis_child
    child_return_status = child.run_analysis(3)
  File "/usr/lib/logdata-anomaly-miner/aminer/AnalysisChild.py", line 234, in run_analysis
    self.analysis_context.build_analysis_pipeline()
  File "/usr/lib/logdata-anomaly-miner/aminer/AnalysisChild.py", line 170, in build_analysis_pipeline
    self.aminer_config.build_analysis_pipeline(self)
  File "/usr/lib/logdata-anomaly-miner/aminer/YamlConfig.py", line 129, in build_analysis_pipeline
    parsing_model = build_parsing_model()
  File "/usr/lib/logdata-anomaly-miner/aminer/YamlConfig.py", line 235, in build_parsing_model
    raise TypeError(msg)
TypeError: "args" has to be a list when using the SequenceModelElement. Currently args is defined as b'testmodel'
sys:1: ResourceWarning: unclosed <socket.socket fd=10, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_DGRAM, proto=0>
aminer: Analysis child process 55875 terminated unexpectedly with signal 0x100
```
