### PR TITLE
Added redpanda to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,23 @@
 version: "3"
 
 services:
+    redpanda:
+        image: docker.vectorized.io/vectorized/redpanda:latest
+        command: ['start --overprovisioned --smp 1 --memory 1G --reserve-memory 0M --node-id 0 --check=false']
+        ports:
+                - "9092:9092"
+                - "9644:9644"
     akafka:
         image: aitaecid/akafka:latest
         environment:
                 KAFKA_TOPICS: '["aminer"]'
-                KAFKA_BOOTSTRAP_SERVERS: localhost:9092
+                KAFKA_BOOTSTRAP_SERVERS: redpanda
         volumes:
             - '$PWD/akafka:/var/lib/akafka'
+        links:
+                - redpanda
+        depends_on:
+                - redpanda
     aminer:
         build:
             context: .
@@ -18,4 +28,3 @@ services:
             - '$PWD/logs:/logs'
         depends_on:
                 - akafka
-

--- a/scripts/prep-docker-compose.sh
+++ b/scripts/prep-docker-compose.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 test -d aminercfg || mkdir aminercfg
+test -d persistency || mkdir persistency
+test -d persistency/log || mkdir persistency/log
+test -d logs || mkdir logs
+test -d akafka || mkdir akafka
 test -e aminercfg/config.yml || cp -r source/root/etc/aminer/template_config.yml aminercfg/config.yml
 test -d aminercfg/conf-enabled || mkdir aminercfg/conf-enabled
 test -e aminercfg/conf-enabled/ApacheAccessModel.py || cp source/root/etc/aminer/conf-available/generic/ApacheAccessModel.py aminercfg/conf-enabled/ApacheAccessModel.py


### PR DESCRIPTION
This commit adds a redpanda(kafka) container to the docker-compose file.
It also improves the prepare-script so that docker-compose works out of
the box.

# Make sure these boxes are signed before submitting your Pull Request -- thank you.

# Must haves
- [x] I have read and followed the contributing guide lines at https://github.com/ait-aecid/logdata-anomaly-miner/wiki/Git-development-workflow
- [x] Issues exist for this PR
- [x] I added related issues using the "Fixes #<issue-id>"-notations
- [x] This Pull-Requests merges into the "development"-branch

Fixes #970

# Submission specific

- [ ] This PR introduces breaking changes
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

# Describe changes:
- add redpanda to docker-compose
- improve prepare-script
