### PR TITLE
153 verbose unparsed atom handler bug

### DIFF
--- a/aecid-testsuite/unit/data/YamlConfigTest.py
+++ b/aecid-testsuite/unit/data/YamlConfigTest.py
@@ -507,7 +507,6 @@ class YamlConfigTest(TestBase):
         context = AnalysisContext(aminer_config)
         context.build_analysis_pipeline()
 
-        print(context.registered_components)
         context.aminer_config.yaml_data['Analysis'][2]['suppress'] = False
         context.atomizer_factory.event_handler_list[0].stream = self.output_stream
         default_nmpd = context.registered_components[3][0]
@@ -528,7 +527,7 @@ class YamlConfigTest(TestBase):
         self.assertEqual(self.output_stream.getvalue(), "")
         self.reset_output_stream()
 
-        value_combo_det = context.registered_components[2][0]
+        value_combo_det = context.registered_components[1][0]
         log_atom_sequence_me = LogAtom(match_element_sequence_me.get_match_string(), ParserMatch(match_element_sequence_me), t,
                                        value_combo_det)
         context.atomizer_factory.event_handler_list[0].stream = self.output_stream
@@ -538,10 +537,10 @@ class YamlConfigTest(TestBase):
             'ValueComboDetector', 1, string2))
         self.reset_output_stream()
 
-        context.aminer_config.yaml_data['Analysis'][1]['suppress'] = True
+        context.aminer_config.yaml_data['Analysis'][0]['suppress'] = True
         context = AnalysisContext(aminer_config)
         context.build_analysis_pipeline()
-        value_combo_det = context.registered_components[2][0]
+        value_combo_det = context.registered_components[1][0]
         context.atomizer_factory.event_handler_list[0].stream = self.output_stream
         self.assertTrue(value_combo_det.receive_atom(log_atom_sequence_me))
         self.assertEqual(self.output_stream.getvalue(), "")

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/YamlConfig.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/YamlConfig.py
@@ -336,11 +336,8 @@ def build_analysis_components(analysis_context, anomaly_event_handlers, atom_fil
         for item in yaml_data['Analysis']:
             if item['type'].name in ('SimpleUnparsedAtomHandler', 'VerboseUnparsedAtomHandler'):
                 has_unparsed_handler = True
-                index = yaml_data['Analysis'].index(item)
-                new_analysis_list = [item]
-                del yaml_data['Analysis'][index]
-                new_analysis_list += yaml_data['Analysis']
-                yaml_data['Analysis'] = new_analysis_list
+                # make room for the UnparsedAtomHandler.
+                atom_filter.add_handler(None, True)
                 break
         for item in yaml_data['Analysis']:
             if item['type'].name == 'NewMatchPathDetector':
@@ -799,14 +796,11 @@ def build_analysis_components(analysis_context, anomaly_event_handlers, atom_fil
                     id_path_list=item['id_path_list'], ignore_list=item['ignore_list'], allow_missing_id=item['allow_missing_id'],
                     num_log_lines_solidify_matrix=item['num_log_lines_solidify_matrix'],
                     time_output_threshold=item['time_output_threshold'], anomaly_threshold=item['anomaly_threshold'])
-            elif item["type"].name == "VerboseUnparsedAtomHandler":
+            elif item["type"].name in ("VerboseUnparsedAtomHandler", "SimpleUnparsedAtomHandler"):
                 has_unparsed_handler = True
                 stop_when_handled_flag = True
                 tmp_analyser = func(anomaly_event_handlers, parsing_model)
-            elif item["type"].name == "SimpleUnparsedAtomHandler":
-                has_unparsed_handler = True
-                stop_when_handled_flag = True
-                tmp_analyser = func(anomaly_event_handlers)
+                atom_filter.subhandler_list[0] = (tmp_analyser, stop_when_handled_flag)
             else:
                 tmp_analyser = func(analysis_context.aminer_config, item['paths'], anomaly_event_handlers, auto_include_flag=learn)
             if item['output_event_handlers'] is not None:

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/YamlConfig.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/YamlConfig.py
@@ -801,6 +801,7 @@ def build_analysis_components(analysis_context, anomaly_event_handlers, atom_fil
                 stop_when_handled_flag = True
                 tmp_analyser = func(anomaly_event_handlers, parsing_model)
                 atom_filter.subhandler_list[0] = (tmp_analyser, stop_when_handled_flag)
+                continue
             else:
                 tmp_analyser = func(analysis_context.aminer_config, item['paths'], anomaly_event_handlers, auto_include_flag=learn)
             if item['output_event_handlers'] is not None:

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/YamlConfig.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/YamlConfig.py
@@ -799,7 +799,10 @@ def build_analysis_components(analysis_context, anomaly_event_handlers, atom_fil
             elif item["type"].name in ("VerboseUnparsedAtomHandler", "SimpleUnparsedAtomHandler"):
                 has_unparsed_handler = True
                 stop_when_handled_flag = True
-                tmp_analyser = func(anomaly_event_handlers, parsing_model)
+                if item["type"].name == "VerboseUnparsedAtomHandler":
+                    tmp_analyser = func(anomaly_event_handlers, parsing_model)
+                else:
+                    tmp_analyser = func(anomaly_event_handlers)
                 analysis_context.register_component(tmp_analyser, component_name=comp_name)
                 atom_filter.subhandler_list[0] = (tmp_analyser, stop_when_handled_flag)
                 continue

--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/YamlConfig.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/YamlConfig.py
@@ -800,6 +800,7 @@ def build_analysis_components(analysis_context, anomaly_event_handlers, atom_fil
                 has_unparsed_handler = True
                 stop_when_handled_flag = True
                 tmp_analyser = func(anomaly_event_handlers, parsing_model)
+                analysis_context.register_component(tmp_analyser, component_name=comp_name)
                 atom_filter.subhandler_list[0] = (tmp_analyser, stop_when_handled_flag)
                 continue
             else:


### PR DESCRIPTION
# Make sure these boxes are signed before submitting your Pull Request -- thank you.

# Must haves
- [x] I have read and followed the contributing guide lines at https://github.com/ait-aecid/logdata-anomaly-miner/wiki/Git-development-workflow
- [x] Issues exist for this PR
- [x] I added related issues using the "Fixes #<issue-id>"-notations
- [x] This Pull-Requests merges into the "development"-branch

Fixes #1000 

# Submission specific

- [ ] This PR introduces breaking changes
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

# Describe changes:
The error happens, because the VerboseUnparsedAtomHandler (also the SimpleUnparsedAtomHandler) must be the first analysis component in the list. This case was missed, because normally the VerboseUnparsedAtomHandler does not need to be defined in the config.

By adding a placeholder entry and replacing it later on, the problem could be fixed.
