### PR TITLE
addbuildid.sh should return 0 if not a git-repo

### DIFF
--- a/scripts/addbuildid.sh
+++ b/scripts/addbuildid.sh
@@ -16,7 +16,7 @@ BUILD_ID=`git describe --tags --long 2> /dev/null`
 if [ $? -ne 0 ]
 then
 	echo "This seems not to be a git installation."
-	exit 1
+	exit 0
 fi
 
 BUILD_ID=`echo $BUILD_ID | sed 's/^[Vv]//'`


### PR DESCRIPTION
This commit fixes the addbuildid.sh when executed in a
non-git-repo-directory. It must also return 0 in such cases otherwhise
some tools like ci-pipelines might fail just because a buildid was not
added correctly.

# Make sure these boxes are signed before submitting your Pull Request -- thank you.

# Must haves
- [x] I have read and followed the contributing guide lines at https://github.com/ait-aecid/logdata-anomaly-miner/wiki/Git-development-workflow
- [x] Issues exist for this PR
- [x] I added related issues using the "Fixes #<issue-id>"-notations
- [x] This Pull-Requests merges into the "development"-branch

Fixes #1038

# Submission specific

- [ ] This PR introduces breaking changes
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

# Describe changes:
- addbuildid.sh returns no 0 if it is executed in a non-git-deployment
