### PR TITLE
remove aecid-testsuite from deepsource

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -13,5 +13,5 @@ name = "test-coverage"
 enabled = true
 
 exclude_patterns = [
-  "aecid-testsuite/system/performance-tests/results/*/*/*.py"
+  "aecid-testsuite/**"
 ]


### PR DESCRIPTION
This commit excludeds aecid-testsuite from deepsource.

# Make sure these boxes are signed before submitting your Pull Request -- thank you.

# Must haves
- [ ] I have read and followed the contributing guide lines at https://github.com/ait-aecid/logdata-anomaly-miner/wiki/Git-development-workflow
- [ ] Issues exist for this PR
- [ ] I added related issues using the "Fixes #<issue-id>"-notations
- [ ] This Pull-Requests merges into the "development"-branch

Fixes DeepSource Issues

# Submission specific

- [ ] This PR introduces breaking changes
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

# Describe changes:
- excludes aecid-testsuite from Deepsource
