### PR TITLE
BUG: Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,26 +8,6 @@ void setBuildStatus(String message, String state) {
     ]);
 }
 
-boolean isBranchIndexingCause() {
-    def isBranchIndexing = false
-    if (!currentBuild.rawBuild) {
-      return true
-    }
-
-    currentBuild.rawBuild.getCauses().each { cause ->
-        if (cause instanceof jenkins.branch.BranchIndexingCause) {
-            isBranchIndexing = true
-        }
-    }
-    return isBranchIndexing
-}
-
-// execute this before anything else, including requesting any time on an agent
-if (isBranchIndexingCause() || currentBuild.getBuildCauses().toString().contains("BranchIndexingCause")) {
-  setBuildStatus("Build skipped due to trigger being Branch Indexing", currentBuild.getPreviousBuild().result);
-  return
-}
-
 def  ubuntu18image = false
 def  ubuntu20image = false
 def  debianbusterimage = false


### PR DESCRIPTION
# Make sure these boxes are signed before submitting your Pull Request -- thank you.

# Must haves
- [ ] I have read and followed the contributing guide lines at https://github.com/ait-aecid/logdata-anomaly-miner/wiki/Git-development-workflow
- [ ] Issues exist for this PR
- [ ] I added related issues using the "Fixes #<issue-id>"-notations
- [ ] This Pull-Requests merges into the "development"-branch

Fixes #

# Submission specific

- [ ] This PR introduces breaking changes
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

# Describe changes:
- The last changes in the Jenkinsfile break the CI!
- Scripts not permitted to use method org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper getRawBuild. [Administrators can decide whether to approve or reject this signature.](https://aecidjenkins.ait.ac.at/scriptApproval)
- As I have found a solution in the configuration, these checks are not needed any more.
