### PR TITLE
Hotfix: add importlib-metadata module.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ RUN ln -s /usr/lib/logdata-anomaly-miner/aminerremotecontrol.py /usr/bin/aminerr
 
 RUN PACK=$(find /usr/lib/python3/dist-packages -name posix1e.cpython\*.so) && FILE=$(echo $PACK | awk -F '/' '{print $NF}') ln -s $PACK /usr/lib/logdata-anomaly-miner/$FILE
 
-RUN pip3 install orjson
+RUN pip3 install orjson importlib-metadata
 RUN PACK=$(find /usr/local/lib/ -name orjson.cpython\*.so) && FILE=$(echo $PACK | awk -F '/' '{print $NF}') ln -s $PACK /usr/lib/logdata-anomaly-miner/$FILE
 
 

--- a/aecid-testsuite/Dockerfile
+++ b/aecid-testsuite/Dockerfile
@@ -127,7 +127,7 @@ ADD scripts/testingwrapper.sh /testingwrapper.sh
 ADD source /home/aminer/source
 ADD docs /home/aminer/docs
 
-RUN pip3 install orjson
+RUN pip3 install orjson importlib-metadata
 RUN PACK=$(find /usr/local/lib/ -name orjson.cpython\*.so) && FILE=$(echo $PACK | awk -F '/' '{print $NF}') ln -s $PACK /usr/lib/logdata-anomaly-miner/$FILE
 
 USER aminer


### PR DESCRIPTION
# Make sure these boxes are signed before submitting your Pull Request -- thank you.

# Must haves
- [x] I have read and followed the contributing guide lines at https://github.com/ait-aecid/logdata-anomaly-miner/wiki/Git-development-workflow
- [ ] Issues exist for this PR
- [ ] I added related issues using the "Fixes #<issue-id>"-notations
- [x] This Pull-Requests merges into the "development"-branch

Fixes #

# Submission specific

- [ ] This PR introduces breaking changes
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

# Describe changes:
- In the development branch Test Ubuntu 18.04 fails, because it is missing the importlib-metadata module, which is automatically included in python only since 3.8.
